### PR TITLE
Changed to use enums in percentage class

### DIFF
--- a/DAT257AgileProject/Assets/Prefabs/Fishing Spot.prefab
+++ b/DAT257AgileProject/Assets/Prefabs/Fishing Spot.prefab
@@ -102,15 +102,15 @@ MonoBehaviour:
   fishingSprite2: {fileID: 0}
   fishingSpotRarities:
     trashRarityPercentages:
-    - Name: Common
+    - trashRarity: 0
       percentage: 0.2
-    - Name: Uncommon
+    - trashRarity: 1
       percentage: 0.2
-    - Name: Rare
+    - trashRarity: 2
       percentage: 0.2
-    - Name: Epic
+    - trashRarity: 3
       percentage: 0.2
-    - Name: Legendary
+    - trashRarity: 4
       percentage: 0.2
   exclamationMarkPrefab: {fileID: 8678099781156329870, guid: ea15b8ae6ec919142b49b5f63fe71c11, type: 3}
 --- !u!61 &4582509056629564299

--- a/DAT257AgileProject/Assets/Scripts/Fishing/RarityPercentageData.cs
+++ b/DAT257AgileProject/Assets/Scripts/Fishing/RarityPercentageData.cs
@@ -5,9 +5,8 @@ using UnityEngine;
  
  
  [Serializable] 
- public class RarityPercentageData{
-
-    public string Name;
+ public class RarityPercentageData
+{
+    public TrashRarity trashRarity;
     public float percentage;
-
  }


### PR DESCRIPTION
Changed it so that it uses enums instead of having to write strings. You can decide if this is better or not. One advantage is not needing to have to write the name, you can now just select the enum. One disadvantage is that the names doesn't show up in the list overview. 